### PR TITLE
Code refactor and minor code optimize

### DIFF
--- a/src/AccelRes.hpp
+++ b/src/AccelRes.hpp
@@ -52,7 +52,7 @@ class AccelRes
 public:
     typedef AccelTableEntry             entry_type;
     typedef std::vector<entry_type>     entries_type;
-    AccelRes() { }
+    AccelRes() = default;
 
     bool LoadFromStream(const MByteStreamEx& stream);
     MStringW Dump(const MIdOrString &id_or_str) const;
@@ -100,14 +100,14 @@ inline MStringW GetKeyFlags(WORD fFlags)
 inline void SetKeyFlags(WORD& fFlags, const MStringW& str)
 {
     fFlags = 0;
-    if (str.find(L"V") != MStringW::npos)
+    if (str.find(L'V') != MStringW::npos)
         fFlags |= FVIRTKEY;
-    if (str.find(L"N") != MStringW::npos)
+    if (str.find(L'N') != MStringW::npos)
         fFlags |= FNOINVERT;
-    if (str.find(L"C") != MStringW::npos)
+    if (str.find(L'C') != MStringW::npos)
         fFlags |= FCONTROL;
-    if (str.find(L"S") != MStringW::npos)
+    if (str.find(L'S') != MStringW::npos)
         fFlags |= FSHIFT;
-    if (str.find(L"A") != MStringW::npos)
+    if (str.find(L'A') != MStringW::npos)
         fFlags |= FALT;
 }

--- a/src/ConstantsDB.hpp
+++ b/src/ConstantsDB.hpp
@@ -179,9 +179,7 @@ public:
         return IDTYPE_RESOURCE;
     }
 
-    ConstantsDB()
-    {
-    }
+    ConstantsDB() = default;
 
     TableType GetTable(CategoryType category) const
     {
@@ -229,7 +227,7 @@ public:
         return table;
     }
 
-    BOOL GetValueOfName(NameType name, ValueType& value) const
+    BOOL GetValueOfName(const NameType& name, ValueType& value) const
     {
         TableType table = GetWholeTable();
         for (const auto& table_entry : table)
@@ -243,7 +241,7 @@ public:
         return FALSE;
     }
 
-    ValueType GetResIDValue(NameType name) const
+    ValueType GetResIDValue(const NameType& name) const
     {
         ValueType value = GetValue(L"RESOURCE.ID", name);
         if (!value)
@@ -252,14 +250,14 @@ public:
         }
         return value;
     }
-    ValueType GetCtrlIDValue(NameType name) const
+    ValueType GetCtrlIDValue(const NameType& name) const
     {
         if (name == L"IDC_STATIC")
             return -1;
         return GetValue(L"CTRLID", name);
     }
 
-    bool HasCtrlID(NameType name) const
+    bool HasCtrlID(const NameType& name) const
     {
         if (name == L"IDC_STATIC")
             return true;
@@ -272,7 +270,7 @@ public:
         }
         return false;
     }
-    bool HasResID(NameType name) const
+    bool HasResID(const NameType& name) const
     {
         TableType table = GetTable(L"RESOURCE.ID");
         for (auto& table_entry : table)
@@ -424,7 +422,7 @@ public:
         return ret;
     }
 
-    NameType GetName(CategoryType category, ValueType value) const
+    NameType GetName(const CategoryType& category, ValueType value) const
     {
         const TableType& table = GetTable(category);
         TableType::const_iterator it, end = table.end();
@@ -450,7 +448,7 @@ public:
         return mstr_dec_short((SHORT)value);
     }
 
-    ValueType GetValue(CategoryType category, NameType name) const
+    ValueType GetValue(const CategoryType& category, const NameType& name) const
     {
         const TableType& table = GetTable(category);
         TableType::const_iterator it, end = table.end();
@@ -462,7 +460,7 @@ public:
         return (ValueType)mstr_parse_int(name.c_str());
     }
 
-    ValueType GetValueI(CategoryType category, NameType name) const
+    ValueType GetValueI(const CategoryType& category, const NameType& name) const
     {
         const TableType& table = GetTable(category);
         TableType::const_iterator it, end = table.end();
@@ -474,7 +472,7 @@ public:
         return (ValueType)mstr_parse_int(name.c_str());
     }
 
-    ValuesType GetValues(CategoryType category, NameType name) const
+    ValuesType GetValues(const CategoryType& category, const NameType& name) const
     {
         ValuesType ret;
         const TableType& table = GetTable(category);
@@ -596,7 +594,7 @@ public:
         return true;
     }
 
-    StringType DumpBitField(CategoryType cat1, ValueType& value,
+    StringType DumpBitField(const CategoryType& cat1, ValueType& value,
                             ValueType default_value = 0) const
     {
         StringType ret, str1, str3;
@@ -609,7 +607,7 @@ public:
 
         if (!str1.empty())
         {
-            ret = str1;
+            ret = std::move(str1);
         }
         else
         {
@@ -637,7 +635,7 @@ public:
         return ret;
     }
 
-    StringType DumpBitFieldOrZero(CategoryType cat1, ValueType& value,
+    StringType DumpBitFieldOrZero(const CategoryType& cat1, ValueType& value,
                                   ValueType default_value = 0) const
     {
         StringType ret = DumpBitField(cat1, value, default_value);
@@ -646,7 +644,7 @@ public:
         return ret;
     }
 
-    StringType DumpBitField(CategoryType cat1, CategoryType cat2,
+    StringType DumpBitField(const CategoryType& cat1, const CategoryType& cat2,
                             ValueType& value, ValueType default_value = 0) const
     {
         StringType ret, str1, str2, str3, str4;
@@ -664,12 +662,12 @@ public:
             if (!str2.empty() && str2 != L"0")
                 ret = str1 + L" | " + str2;
             else
-                ret = str1;
+                ret = std::move(str1);
         }
         else
         {
             if (!str2.empty() && str2 != L"0")
-                ret = str2;
+                ret = std::move(str2);
             else
                 ret = L"0";
         }
@@ -700,7 +698,7 @@ public:
         return ret;
     }
 
-    StringType DumpBitFieldOrZero(CategoryType cat1, CategoryType cat2,
+    StringType DumpBitFieldOrZero(const CategoryType& cat1, const CategoryType& cat2,
                                   ValueType& value, ValueType default_value = 0) const
     {
         StringType ret = DumpBitField(cat1, cat2, value, default_value);
@@ -711,8 +709,6 @@ public:
 
     StringType DumpValue(CategoryType category, ValueType value) const
     {
-        StringType ret;
-
         ::CharUpperW(&category[0]);
 
         MapType::const_iterator found = m_map.find(category);

--- a/src/DlgInitRes.hpp
+++ b/src/DlgInitRes.hpp
@@ -44,9 +44,7 @@ struct DlgInitEntry
     WORD        wMsg;
     MStringA    strText;
 
-    DlgInitEntry()
-    {
-    }
+    DlgInitEntry() = default;
     
     DlgInitEntry(WORD ctrl, WORD msg, const MStringA& str)
         : wCtrl(ctrl), wMsg(msg), strText(str)
@@ -66,7 +64,7 @@ protected:
     entries_type    m_entries;
 
 public:
-    DlgInitRes() { }
+    DlgInitRes() = default;
 
     bool LoadFromStream(const MByteStreamEx& stream);
     bool SaveToStream(MByteStreamEx& stream) const;

--- a/src/MAddCtrlDlg.hpp
+++ b/src/MAddCtrlDlg.hpp
@@ -416,7 +416,6 @@ public:
         mstr_trim(text);
         DWORD dwStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_style_selection = m_style_selection;
         GetStyleSelect(m_style_selection, m_style_table, dwStyle);
 
         HWND hLst1 = GetDlgItem(hwnd, lst1);
@@ -433,7 +432,6 @@ public:
         mstr_trim(text);
         DWORD dwExStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_exstyle_selection = m_exstyle_selection;
         GetStyleSelect(m_exstyle_selection, m_exstyle_table, dwExStyle);
 
         HWND hLst2 = GetDlgItem(hwnd, lst2);

--- a/src/MAddResDlg.hpp
+++ b/src/MAddResDlg.hpp
@@ -372,7 +372,7 @@ public:
         }
         else
         {
-            type.m_str = strIDType;
+            type.m_str = std::move(strIDType);
         }
 
         if (HasSample(type, m_lang))

--- a/src/MAddResIDDlg.hpp
+++ b/src/MAddResIDDlg.hpp
@@ -100,7 +100,7 @@ public:
             ErrorBoxDx(IDS_ENTERINT);
             return;
         }
-        m_str2 = str2;
+        m_str2 = std::move(str2);
 
         MStringA str1a = MTextToAnsi(CP_ACP, str1).c_str();
         if (g_settings.id_map.find(str1a) != g_settings.id_map.end())
@@ -161,7 +161,6 @@ public:
                     ConstantsDB::TableType table;
                     table = g_db.GetTable(L"RESOURCE.ID.PREFIX");
 
-                    MString name = GetDlgItemText(hwnd, cmb1);
                     m_bChanging = TRUE;
                     SetDlgItemText(hwnd, edt1, table[k].name.c_str());
                     m_bChanging = FALSE;

--- a/src/MCtrlPropDlg.hpp
+++ b/src/MCtrlPropDlg.hpp
@@ -661,7 +661,6 @@ public:
         mstr_trim(text);
         DWORD dwStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_style_selection = m_style_selection;
         GetStyleSelect(m_style_selection, m_style_table, dwStyle);
 
         HWND hLst1 = GetDlgItem(hwnd, lst1);
@@ -678,7 +677,6 @@ public:
         mstr_trim(text);
         DWORD dwExStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_exstyle_selection = m_exstyle_selection;
         GetStyleSelect(m_exstyle_selection, m_exstyle_table, dwExStyle);
 
         HWND hLst2 = GetDlgItem(hwnd, lst2);

--- a/src/MDlgPropDlg.hpp
+++ b/src/MDlgPropDlg.hpp
@@ -484,7 +484,6 @@ public:
         mstr_trim(text);
         DWORD dwStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_style_selection = m_style_selection;
         GetStyleSelect(m_style_selection, m_style_table, dwStyle);
 
         HWND hLst1 = GetDlgItem(hwnd, lst1);
@@ -501,7 +500,6 @@ public:
         mstr_trim(text);
         DWORD dwExStyle = mstr_parse_int(text.c_str(), false, 16);
 
-        std::vector<BYTE> old_exstyle_selection = m_exstyle_selection;
         GetStyleSelect(m_exstyle_selection, m_exstyle_table, dwExStyle);
 
         HWND hLst2 = GetDlgItem(hwnd, lst2);

--- a/src/MEditToolbarDlg.hpp
+++ b/src/MEditToolbarDlg.hpp
@@ -44,9 +44,8 @@ public:
     std::wstring m_str;
     MComboBoxAutoComplete m_cmb1;
 
-    MModifyTBBtnDlg(INT id, const std::wstring& str = L"") : MDialogBase(id)
+    MModifyTBBtnDlg(INT id, const std::wstring& str = L"") : MDialogBase(id), m_str(str)
     {
-        m_str = str;
     }
 
     BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam)

--- a/src/MEncodingDlg.hpp
+++ b/src/MEncodingDlg.hpp
@@ -33,7 +33,7 @@ class MEncodingDlg;
 
 //////////////////////////////////////////////////////////////////////////////
 
-inline MString txt2enc(MString txt)
+inline MString txt2enc(const MString& txt)
 {
     if (txt == LoadStringDx(IDS_ANSI))
         return L"ansi";
@@ -48,7 +48,7 @@ inline MString txt2enc(MString txt)
     return L"";
 }
 
-inline MString enc2txt(MString enc)
+inline MString enc2txt(const MString& enc)
 {
     if (enc == L"ansi")
         return LoadStringDx(IDS_ANSI);
@@ -81,7 +81,7 @@ inline MIdOrString get_type_from_text(MString str)
     }
     else
     {
-        type.m_str = str;
+        type.m_str = std::move(str);
     }
     return type;
 }

--- a/src/MIDListDlg.hpp
+++ b/src/MIDListDlg.hpp
@@ -661,7 +661,6 @@ public:
                 MString str1 = szText;
                 MStringA astr1 = MTextToAnsi(CP_ACP, szText).c_str();
                 ListView_GetItemText(m_hLst1, iItem, 2, szText, _countof(szText));
-                MStringA astr2 = MTextToAnsi(CP_ACP, szText).c_str();
 
                 ConstantsDB::TableType& table = g_db.m_map[L"RESOURCE.ID"];
                 auto end = table.end();
@@ -677,6 +676,7 @@ public:
                 g_settings.id_map.erase(astr1);
                 if (!g_settings.added_ids.erase(astr1))
                 {
+                    MStringA astr2 = MTextToAnsi(CP_ACP, szText).c_str();
                     g_settings.removed_ids.insert(std::make_pair(astr1, astr2));
                 }
 

--- a/src/MMacrosDlg.hpp
+++ b/src/MMacrosDlg.hpp
@@ -466,7 +466,7 @@ public:
 
                 MString strValue = m_map[m_strTemp];
                 m_map.erase(m_strTemp);
-                m_map[pInfo->item.pszText] = strValue;
+                m_map[pInfo->item.pszText] = std::move(strValue);
 
                 LV_ITEM item;
                 ZeroMemory(&item, sizeof(item));

--- a/src/MMessagesDlg.hpp
+++ b/src/MMessagesDlg.hpp
@@ -32,7 +32,7 @@ class MAddMsgDlg;
 class MModifyMsgDlg;
 class MMessagesDlg;
 
-void InitMessageComboBox(HWND hCmb, MString strString);
+void InitMessageComboBox(HWND hCmb, const MString& strString);
 BOOL MsgDlg_GetEntry(HWND hwnd, MESSAGE_ENTRY& entry);
 void MsgDlg_SetEntry(HWND hwnd, MESSAGE_ENTRY& entry);
 
@@ -414,7 +414,7 @@ public:
             ListView_SetItemText(m_hLst1, iItem, 1, &str[0]);
 
             ULONG dwValue = g_db.GetResIDValue(me.MessageID);
-            m_msg_res.m_map[dwValue] = str;
+            m_msg_res.m_map[dwValue] = std::move(str);
         }
     }
 

--- a/src/MModifyResIDDlg.hpp
+++ b/src/MModifyResIDDlg.hpp
@@ -67,7 +67,7 @@ public:
             ErrorBoxDx(IDS_ENTERTEXT);
             return;
         }
-        m_str1 = str1;
+        m_str1 = std::move(str1);
 
         MString str2 = GetDlgItemText(hwnd, edt1);
         mstr_trim(str2);
@@ -91,7 +91,7 @@ public:
             ErrorBoxDx(IDS_ENTERTEXT);
             return;
         }
-        m_str2 = str3;
+        m_str2 = std::move(str3);
 
         EndDialog(IDOK);
     }

--- a/src/MPathsDlg.hpp
+++ b/src/MPathsDlg.hpp
@@ -167,8 +167,8 @@ public:
         }
 
         g_settings.includes = m_list;
-        g_settings.strWindResExe = strWindResExe;
-        g_settings.strCppExe = strCppExe;
+        g_settings.strWindResExe = std::move(strWindResExe);
+        g_settings.strCppExe = std::move(strCppExe);
 
         EndDialog(IDOK);
     }

--- a/src/MRadWindow.hpp
+++ b/src/MRadWindow.hpp
@@ -2692,7 +2692,7 @@ public:
                 items2.push_back(m_dialog_res[i]);
             }
         }
-        m_dialog_res.m_items = items1;
+        m_dialog_res.m_items = std::move(items1);
         m_dialog_res.m_items.insert(m_dialog_res.m_items.begin(), items2.begin(), items2.end());
 
         // refresh
@@ -2746,7 +2746,7 @@ public:
         }
 
         // swap
-        m_dialog_res.m_items = items1;
+        m_dialog_res.m_items = std::move(items1);
         m_dialog_res.m_items.insert(m_dialog_res.m_items.end(), items2.begin(), items2.end());
 
         // refresh

--- a/src/MResizable.hpp
+++ b/src/MResizable.hpp
@@ -40,7 +40,7 @@ protected:
         HWND m_hwndCtrl;
         MSize m_sizLA_1, m_sizMargin1, m_sizLA_2, m_sizMargin2;
 
-        MCtrlLayout() { }
+        MCtrlLayout() = default;
 
         MCtrlLayout(HWND hwndCtrl, SIZE sizLA_1, SIZE sizMargin1, 
             SIZE sizLA_2, SIZE sizMargin2) : m_hwndCtrl(hwndCtrl), 

--- a/src/MStringsDlg.hpp
+++ b/src/MStringsDlg.hpp
@@ -33,7 +33,7 @@ class MAddStrDlg;
 class MModifyStrDlg;
 class MStringsDlg;
 
-void InitStringComboBox(HWND hCmb, MString strString);
+void InitStringComboBox(HWND hCmb, const MString& strString);
 BOOL StrDlg_GetEntry(HWND hwnd, STRING_ENTRY& entry);
 void StrDlg_SetEntry(HWND hwnd, STRING_ENTRY& entry);
 

--- a/src/MenuRes.cpp
+++ b/src/MenuRes.cpp
@@ -412,7 +412,7 @@ bool MenuRes::SaveToStreamEx(MByteStreamEx& stream) const
 }
 
 MenuRes::string_type
-MenuRes::Dump(MIdOrString name) const
+MenuRes::Dump(const MIdOrString& name) const
 {
     if (IsExtended())
         return DumpEx(name);
@@ -505,7 +505,7 @@ MenuRes::Dump(MIdOrString name) const
 }
 
 MenuRes::string_type
-MenuRes::DumpEx(MIdOrString name) const
+MenuRes::DumpEx(const MIdOrString& name) const
 {
     string_type ret;
 

--- a/src/MenuRes.hpp
+++ b/src/MenuRes.hpp
@@ -140,8 +140,8 @@ public:
     bool LoadFromStreamEx(const MByteStreamEx& stream);
     bool SaveToStream(MByteStreamEx& stream) const;
     bool SaveToStreamEx(MByteStreamEx& stream) const;
-    string_type Dump(MIdOrString name) const;
-    string_type DumpEx(MIdOrString name) const;
+    string_type Dump(const MIdOrString& name) const;
+    string_type DumpEx(const MIdOrString& name) const;
     std::vector<BYTE> data() const;
 
     void Update();

--- a/src/MessageRes.hpp
+++ b/src/MessageRes.hpp
@@ -90,9 +90,7 @@ public:
         return m_map;
     }
 
-    MessageRes()
-    {
-    }
+    MessageRes() = default;
 
     bool empty() const
     {
@@ -134,7 +132,6 @@ public:
                 if (!stream.ReadRaw(entry_head))
                     return false;
 
-                MStringW wstr = reinterpret_cast<const WCHAR *>(&stream[stream.pos()]);
                 if (entry_head.Flags & MESSAGE_RESOURCE_UNICODE)
                 {
                     size_t len = (entry_head.Length - sizeof(entry_head)) / sizeof(WCHAR);
@@ -145,7 +142,7 @@ public:
                         return false;
                     }
                     str.resize(mstrlen(str.c_str()));
-                    m_map[dwID] = str;
+                    m_map[dwID] = std::move(str);
                 }
                 else
                 {

--- a/src/Res.cpp
+++ b/src/Res.cpp
@@ -189,7 +189,7 @@ dfm_text_from_binary(LPCWSTR pszDFMSC, const void *binary, size_t size,
             return text;
     }
 
-    return std::string("");
+    return std::string();
 }
 
 EntryBase::data_type
@@ -331,7 +331,7 @@ tlb_text_from_binary(LPCWSTR pszOleBow, const void *binary, size_t size)
             return text;
     }
 
-    return std::string("");
+    return std::string();
 }
 
 EntryBase::data_type

--- a/src/ResHeader.hpp
+++ b/src/ResHeader.hpp
@@ -97,7 +97,7 @@ public:
         return true;
     }
 
-    DWORD GetHeaderSize(MIdOrString type, MIdOrString name) const
+    DWORD GetHeaderSize(const MIdOrString& type, MIdOrString name) const
     {
         size_t size = 0;
         if (type.is_str())

--- a/src/ResToText.cpp
+++ b/src/ResToText.cpp
@@ -35,7 +35,7 @@
 MString
 ResToText::GetEntryFileName(const EntryBase& entry)
 {
-    MString ret, lang;
+    MString ret;
 
     if (entry.m_type.is_int())
     {
@@ -1097,7 +1097,7 @@ MString ResToText::DoEncodedText(const EntryBase& entry, const MStringW& enc)
             MStringW wide = a2w.c_str();
             mstr_replace_all(wide, L"\r\n", L"\n");
             mstr_replace_all(wide, L"\n", L"\r\n");
-            return wide.c_str();
+            return wide;
         }
         if (enc == L"wide")
         {
@@ -1119,7 +1119,7 @@ MString ResToText::DoEncodedText(const EntryBase& entry, const MStringW& enc)
             MStringW wide = a2w.c_str();
             mstr_replace_all(wide, L"\r\n", L"\n");
             mstr_replace_all(wide, L"\n", L"\r\n");
-            return wide.c_str();
+            return wide;
         }
         if (enc == L"sjis")
         {
@@ -1128,7 +1128,7 @@ MString ResToText::DoEncodedText(const EntryBase& entry, const MStringW& enc)
             MStringW wide = a2w.c_str();
             mstr_replace_all(wide, L"\r\n", L"\n");
             mstr_replace_all(wide, L"\n", L"\r\n");
-            return wide.c_str();
+            return wide;
         }
     }
     else

--- a/src/RisohSettings.hpp
+++ b/src/RisohSettings.hpp
@@ -196,7 +196,7 @@ struct RisohSettings
         assoc_map[L"New.Command.ID"] = L"ID_";
         assoc_map[L"Prompt.ID"] = L"IDP_";
         assoc_map[L"RCData.ID"] = L"IDR_";
-        assoc_map[L"Unknown.ID"] = L"";
+        assoc_map[L"Unknown.ID"].clear();
     }
 
     void ResetMacros()

--- a/src/StringRes.cpp
+++ b/src/StringRes.cpp
@@ -40,7 +40,7 @@ StringRes::LoadFromStream(const MByteStreamEx& stream, WORD wName)
             if (!stream.ReadData(&str[0], wLen * sizeof(WCHAR)))
                 break;
 
-            m_map[(wName - 1) * 16 + i] = str;
+            m_map[(wName - 1) * 16 + i] = std::move(str);
         }
     }
 

--- a/src/StringRes.hpp
+++ b/src/StringRes.hpp
@@ -39,9 +39,7 @@ public:
     WORD        m_wName;
     map_type    m_map;
 
-    StringRes()
-    {
-    }
+    StringRes() = default;
 
     bool LoadFromStream(const MByteStreamEx& stream, WORD wName);
     bool SaveToStream(MByteStreamEx& stream, WORD wName);

--- a/src/ToolbarRes.hpp
+++ b/src/ToolbarRes.hpp
@@ -42,7 +42,7 @@ protected:
     std::vector<DWORD> m_items;
 
 public:
-    ToolbarRes() { }
+    ToolbarRes() = default;
 
     bool LoadFromStream(const MByteStreamEx& stream);
     bool SaveToStream(MByteStreamEx& stream) const;

--- a/src/VersionRes.hpp
+++ b/src/VersionRes.hpp
@@ -54,7 +54,7 @@ typedef std::vector<Var> Vars;
 class VersionRes
 {
 public:
-    VersionRes() { }
+    VersionRes() = default;
 
     bool VarsFromStream(Vars& vars, const MByteStreamEx& stream);
     bool LoadFromData(const std::vector<BYTE>& data);


### PR DESCRIPTION
@katahiromz, str to char in std functions, const reference params, using std::move, use = default for trivial constructors and destructors, lower scope var optimization.